### PR TITLE
fix: isJsonRpcSuccess accepts numeric id

### DIFF
--- a/src/json-rpc-types.ts
+++ b/src/json-rpc-types.ts
@@ -67,7 +67,7 @@ export function isntJsonRpcRequest<T>(val: T): val is Exclude<T, JsonRpcRequest<
 export function isJsonRpcSuccess<T>(val: unknown): val is JsonRpcSuccess<T> {
   return isPlainObject(val)
       && isString(val.jsonrpc)
-      && isString(val.id)
+      && isJsonRpcId(val.id)
       && 'result' in val
 }
 


### PR DESCRIPTION
The `isJsonRpcSuccess` function checks the `id` field with `isString(val.id)` while the JSON-RPC spec states it could be a number, so use `isJsonRpcId(val.id)` instead.